### PR TITLE
Update EC and patches

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1-foss-2022a.eb
@@ -2,7 +2,6 @@ easyblock = 'PythonBundle'
 
 name = 'TensorFlow'
 version = '2.9.1'
-versionsuffix = '-CUDA-%(cudaver)s'
 
 homepage = 'https://www.tensorflow.org/'
 description = "An open-source software library for Machine Intelligence"
@@ -20,9 +19,6 @@ builddependencies = [
     ('LLVM', '14.0.3'),  # for debugging with llvm-symbolizer, to be removed
 ]
 dependencies = [
-    ('CUDA', '11.7.0', '', SYSTEM),
-    ('cuDNN', '8.4.1.50', versionsuffix, SYSTEM),
-    ('NCCL', '2.12.12', versionsuffix),
     ('Python', '3.10.4'),
     ('h5py', '3.7.0'),
     ('cURL', '7.83.0'),

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1_remove-duplicate-gpu-tests.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1_remove-duplicate-gpu-tests.patch
@@ -1,0 +1,55 @@
+TensorFlow adds some GPU tests twice increasing the runtime of the test suite.
+This filters out the test part meant for CPU.
+
+See https://github.com/tensorflow/tensorflow/issues/47081
+From https://github.com/tensorflow/tensorflow/pull/59129
+
+Author: Alexander Grund (TU Dresden)
+---
+ tensorflow/tensorflow.bzl | 33 +++++++++++++++++----------------
+ 1 file changed, 17 insertions(+), 16 deletions(-)
+
+diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
+index 649c8e22dcc95..d3fc0e3221497 100644
+--- a/tensorflow/tensorflow.bzl
++++ b/tensorflow/tensorflow.bzl
+@@ -1461,22 +1461,23 @@ def tf_gpu_cc_test(
+         linkopts = [],
+         **kwargs):
+     targets = []
+-    tf_cc_test(
+-        name = name,
+-        size = size,
+-        srcs = srcs,
+-        args = args,
+-        data = data,
+-        extra_copts = extra_copts + if_cuda(["-DNV_CUDNN_DISABLE_EXCEPTION"]),
+-        kernels = kernels,
+-        linkopts = linkopts,
+-        linkstatic = linkstatic,
+-        suffix = "_cpu",
+-        tags = tags,
+-        deps = deps,
+-        **kwargs
+-    )
+-    targets.append(name + "_cpu")
++    if 'gpu' not in tags:
++        tf_cc_test(
++            name = name,
++            size = size,
++            srcs = srcs,
++            args = args,
++            data = data,
++            extra_copts = extra_copts + if_cuda(["-DNV_CUDNN_DISABLE_EXCEPTION"]),
++            kernels = kernels,
++            linkopts = linkopts,
++            linkstatic = linkstatic,
++            suffix = "_cpu",
++            tags = tags,
++            deps = deps,
++            **kwargs
++        )
++        targets.append(name + "_cpu")
+     tf_cc_test(
+         name = name,
+         size = size,

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1_remove-libclang-and-io-gcs-deps.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.9.1_remove-libclang-and-io-gcs-deps.patch
@@ -1,0 +1,35 @@
+This combines two patches from TensorFlow 2.7.1.
+
+tensorflow-io-gcs-filesystem is not available as a binary for all architectures and
+building it requires TensorFlow to be installed, i.e. there is a cyclic dependency.
+As it is not actually required (but optional) remove it from `REQUIRED_PACKAGES`.
+See https://github.com/tensorflow/tensorflow/issues/56636
+
+libclang was introduced in
+https://github.com/tensorflow/tensorflow/commit/c211472000ff57bac7fcec9b0465cf73b37bf135
+> This is in preparation to open-source TF's TFRT backend.
+> TFRT generates code using libclang python bindings as part of the build.
+Hence it is not currently used and as it is not (easily) available for all architectures
+simply remove it.
+
+Patch added by Simon Branford (University of Birmingham)
+Updated by Alexander Grund (TU Dresden)
+
+--- a/tensorflow/tools/pip_package/setup.py
++++ b/tensorflow/tools/pip_package/setup.py
+@@ -83,7 +83,6 @@ REQUIRED_PACKAGES = [
+     'google_pasta >= 0.1.1',
+     'h5py >= 2.9.0',
+     'keras_preprocessing >= 1.1.1',  # 1.1.0 needs tensorflow==1.7
+-    'libclang >= 13.0.0',
+     'numpy >= 1.20',
+     'opt_einsum >= 2.3.2',
+     'packaging',
+@@ -100,7 +99,6 @@ REQUIRED_PACKAGES = [
+     'termcolor >= 1.1.0',
+     'typing_extensions >= 3.6.6',
+     'wrapt >= 1.11.0',
+-    'tensorflow-io-gcs-filesystem >= 0.23.1',
+     # grpcio does not build correctly on big-endian machines due to lack of
+     # BoringSSL support.
+     # See https://github.com/tensorflow/tensorflow/issues/17882.


### PR DESCRIPTION
This is an intermediate step to get the EC working.

Some python packages must be removed as they don't work on non-x86 architectures. I also updated  the checksums and moved them to the sources.

It also requires:

- [ ] Patches from https://github.com/easybuilders/easybuild-easyconfigs/pull/17058
- [ ] EC from https://github.com/easybuilders/easybuild-easyconfigs/pull/17060

A major blocker will be resolved with https://github.com/easybuilders/easybuild-easyblocks/pull/2854

Still not done but my progress so far. If you don't want to continue with https://github.com/easybuilders/easybuild-easyconfigs/pull/16620 then close that and I'll open one once I got the build and tests working on PPC